### PR TITLE
Modify login to use Student username instead of name

### DIFF
--- a/webquizappbackend/quizzes/views.py
+++ b/webquizappbackend/quizzes/views.py
@@ -109,7 +109,7 @@ def student_detail(request, pk):
 @api_view(['GET'])
 def username_getStudentFromUsername(request, username):
     try:
-        student = Student.objects.get(student_name=username)
+        student = Student.objects.get(student_username=username)
     except Student.DoesNotExist:
         return JsonResponse({'message': 'The student does not exist'}, status=status.HTTP_404_NOT_FOUND)
 


### PR DESCRIPTION
Tested by quickly attempting to login using a student username instead of a student name. 